### PR TITLE
Use buildpulse/test-reporter for big speedup

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -47,6 +47,22 @@ commands:
     description: Send test results to BuildPulse.
 
     parameters:
+      access-key-id:
+        description: |
+          BuildPulse access key ID. Set this to the name of the environment
+          variable you will use to hold this value
+          (e.g., BUILDPULSE_ACCESS_KEY_ID).
+        type: env_var_name
+        default: BUILDPULSE_ACCESS_KEY_ID
+
+      secret-access-key:
+        description: |
+          BuildPulse secret access key. Set this to the name of the environment
+          variable you will use to hold this value
+          (e.g., BUILDPULSE_SECRET_ACCESS_KEY).
+        type: env_var_name
+        default: BUILDPULSE_SECRET_ACCESS_KEY
+
       account-id:
         description: |
           BuildPulse's unique identifier for the account that owns the
@@ -132,30 +148,13 @@ commands:
               exit 1
             fi
 
-            METADATA_PATH=${REPORT_PATH}/buildpulse.yml
-            TIMESTAMP=$(date --iso-8601=seconds)
-            UUID=$(cat /proc/sys/kernel/random/uuid)
+            curl -fsSL https://github.com/buildpulse/test-reporter/releases/latest/download/test-reporter-linux-amd64 > ./buildpulse-test-reporter
 
-            cat \<< EOF > "$METADATA_PATH"
-            ---
-            :branch: $CIRCLE_BRANCH
-            :build_url: $CIRCLE_BUILD_URL
-            :check: ${BUILDPULSE_CHECK_NAME:-circleci}
-            :commit: $CIRCLE_SHA1
-            :job: $CIRCLE_JOB
-            :repo_name: $CIRCLE_PROJECT_REPONAME
-            :repo_owner: $CIRCLE_PROJECT_USERNAME
-            :repo_url: $CIRCLE_REPOSITORY_URL
-            :timestamp: '$TIMESTAMP'
-            :workflow_id: $CIRCLE_WORKFLOW_ID
-            EOF
+            chmod +x ./buildpulse-test-reporter
 
-            ARCHIVE_PATH=/tmp/buildpulse-${UUID}.gz
-            tar -zcf "${ARCHIVE_PATH}" "${REPORT_PATH}"
-
-            S3_URL=s3://$ACCOUNT_ID.buildpulse-uploads/$REPOSITORY_ID/
-
-            aws s3 cp "${ARCHIVE_PATH}" "${S3_URL}" --profile buildpulse
+            BUILDPULSE_ACCESS_KEY_ID=$<< parameters.access-key-id >> \
+              BUILDPULSE_SECRET_ACCESS_KEY=$<< parameters.secret-access-key >> \
+              ./buildpulse-test-reporter submit "${REPORT_PATH}" --account-id $ACCOUNT_ID --repository-id $REPOSITORY_ID
 
 examples:
   send-test-results-to-buildpulse:
@@ -172,11 +171,6 @@ examples:
             - image: circleci/<some-docker-image>
           steps:
             - checkout
-
-            # 📣 Be sure to execute this step *before* running your tests
-            - buildpulse/setup:
-                access-key-id: BUILDPULSE_ACCESS_KEY_ID
-                secret-access-key: BUILDPULSE_SECRET_ACCESS_KEY
 
             - run: echo "Run your tests and generate XML reports for your test results"
 

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -6,42 +6,23 @@ description: |
 display:
   home_url: https://github.com/Workshop64/buildpulse-circleci-orb
 
-orbs:
-  aws-cli: circleci/aws-cli@0.1.19
-
 commands:
   setup:
-    description: |
-      Install BuildPulse uploader and optionally configure credentials.
-      📣 Be sure to run this command *before* running your tests.
+    description: Deprecated. This command is no longer needed and no longer used. It will be removed in an upcoming release.
 
     parameters:
       access-key-id:
-        description: |
-          BuildPulse access key ID. Set this to the name of the environment
-          variable you will use to hold this value
-          (e.g., BUILDPULSE_ACCESS_KEY_ID).
+        description: Deprecated. This parameter is no longer needed and no longer used.
         type: env_var_name
         default: BUILDPULSE_ACCESS_KEY_ID
 
       secret-access-key:
-        description: |
-          BuildPulse secret access key. Set this to the name of the environment
-          variable you will use to hold this value
-          (e.g., BUILDPULSE_SECRET_ACCESS_KEY).
+        description: Deprecated. This parameter is no longer needed and no longer used.
         type: env_var_name
         default: BUILDPULSE_SECRET_ACCESS_KEY
 
     steps:
-      - run:
-          name: Configure BuildPulse region
-          command: echo "export BUILDPULSE_REGION=us-east-2" >> $BASH_ENV
-
-      - aws-cli/setup:
-          profile-name: buildpulse
-          aws-region: BUILDPULSE_REGION
-          aws-access-key-id: << parameters.access-key-id >>
-          aws-secret-access-key: << parameters.secret-access-key >>
+      - run: echo "⚠️⚠️⚠️ The buildpulse/setup command is deprecated. Please remove it from your workflow. This command is no longer needed, and it will be removed in an upcoming release."
 
   upload:
     description: Send test results to BuildPulse.

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -135,7 +135,9 @@ commands:
         default: BUILDPULSE_SECRET_ACCESS_KEY
 
     steps:
-      - run: echo "⚠️⚠️⚠️ The buildpulse/setup command is deprecated. Please remove it from your workflow. This command is no longer needed, and it will be removed in an upcoming release."
+      - run:
+          name: "Announce deprecation of buildpulse/setup command"
+          command: echo "⚠️⚠️⚠️ The buildpulse/setup command is deprecated. Please remove it from your workflow. This command is no longer needed, and it will be removed in an upcoming release."
 
 examples:
   send-test-results-to-buildpulse:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -7,23 +7,6 @@ display:
   home_url: https://github.com/Workshop64/buildpulse-circleci-orb
 
 commands:
-  setup:
-    description: Deprecated. This command is no longer needed and no longer used. It will be removed in an upcoming release.
-
-    parameters:
-      access-key-id:
-        description: Deprecated. This parameter is no longer needed and no longer used.
-        type: env_var_name
-        default: BUILDPULSE_ACCESS_KEY_ID
-
-      secret-access-key:
-        description: Deprecated. This parameter is no longer needed and no longer used.
-        type: env_var_name
-        default: BUILDPULSE_SECRET_ACCESS_KEY
-
-    steps:
-      - run: echo "⚠️⚠️⚠️ The buildpulse/setup command is deprecated. Please remove it from your workflow. This command is no longer needed, and it will be removed in an upcoming release."
-
   upload:
     description: Send test results to BuildPulse.
 
@@ -136,6 +119,23 @@ commands:
             BUILDPULSE_ACCESS_KEY_ID=$<< parameters.access-key-id >> \
               BUILDPULSE_SECRET_ACCESS_KEY=$<< parameters.secret-access-key >> \
               ./buildpulse-test-reporter submit "${REPORT_PATH}" --account-id $ACCOUNT_ID --repository-id $REPOSITORY_ID
+
+  setup:
+    description: Deprecated. This command is no longer needed and no longer used. It will be removed in an upcoming release.
+
+    parameters:
+      access-key-id:
+        description: Deprecated. This parameter is no longer needed and no longer used.
+        type: env_var_name
+        default: BUILDPULSE_ACCESS_KEY_ID
+
+      secret-access-key:
+        description: Deprecated. This parameter is no longer needed and no longer used.
+        type: env_var_name
+        default: BUILDPULSE_SECRET_ACCESS_KEY
+
+    steps:
+      - run: echo "⚠️⚠️⚠️ The buildpulse/setup command is deprecated. Please remove it from your workflow. This command is no longer needed, and it will be removed in an upcoming release."
 
 examples:
   send-test-results-to-buildpulse:


### PR DESCRIPTION
- Remove dependency on aws-cli orb
- Use [buildpulse/test-reporter](https://github.com/buildpulse/test-reporter) for smaller installation footprint and faster execution
- Deprecate the obsolete buildpulse/setup command
